### PR TITLE
fix: remove blueprint duplicate url prefix

### DIFF
--- a/app/routes/forecast_risk_blueprint.py
+++ b/app/routes/forecast_risk_blueprint.py
@@ -4,4 +4,4 @@ from app.controllers import forecast_risk_controller
 
 bp = Blueprint("bp_forecast_risk", __name__, "/forecast-risk")
 
-bp.post("/forecast-risk")(forecast_risk_controller.fetch_forecast_risk)
+bp.post("")(forecast_risk_controller.fetch_forecast_risk)

--- a/app/routes/forecast_risk_blueprint.py
+++ b/app/routes/forecast_risk_blueprint.py
@@ -2,6 +2,6 @@ from flask import Blueprint
 
 from app.controllers import forecast_risk_controller
 
-bp = Blueprint("bp_forecast_risk", __name__, "/forecast-risk")
+bp = Blueprint("bp_forecast_risk", __name__, url_prefix="/forecast-risk")
 
 bp.post("")(forecast_risk_controller.fetch_forecast_risk)


### PR DESCRIPTION
Fix the 'forecast-risk' blueprint duplicate url prefix.