### PR TITLE
feat: sms-send-logic-code-changes-default-risk

### DIFF
--- a/app/controllers/forecast_risk_controller.py
+++ b/app/controllers/forecast_risk_controller.py
@@ -1,10 +1,13 @@
+import asyncio
 from http import HTTPStatus
 
 from flask import request
 
 from app.decorators.forecast_risk_decorator import request_validator
 from app.models import RiskModel
-from app.services.forecast_risk_services import get_endangered_cities
+from app.services.communication_services import sms_send
+from app.services.forecast_risk_services import get_endangered_cities_and_users
+from app.utils.phone_only_numbers_formatter import phone_with_only_numbers
 
 
 @request_validator
@@ -12,8 +15,20 @@ def fetch_forecast_risk():
 
     data = request.get_json()
 
-    endangered_cities = get_endangered_cities(data, RiskModel.PRECIPITATION_LIMIT)
+    endangered_cities, users = get_endangered_cities_and_users(
+        data, RiskModel.PRECIPITATION_LIMIT
+    )
 
-    # TODO add the logic to send an message to the desired users.
+    # This logic is to limit the users to only 10 results
+    # i think we should delete this to the heroku application
+    # and use only real data from there
+    # Another suggestion would be to limit the sms function to raise
+    # an error when overloading our limit
+    users = users[:10]
+
+    for user in users:
+        message = user.risks[0].text
+        phone = phone_with_only_numbers(user.phone)
+        asyncio.run(sms_send(phone, message))
 
     return {"endangered_cities": endangered_cities}, HTTPStatus.OK

--- a/app/controllers/user_controller.py
+++ b/app/controllers/user_controller.py
@@ -16,6 +16,7 @@ from app.exceptions.user_exc import UserNotFound
 from app.models.address_model import AddressModel
 from app.models.user_model import UserModel
 from app.services.generic_services import get_user_from_token
+from app.services.user_risk_profile_services import insert_default_risk
 from app.services.user_services import validate_keys_and_values
 from app.utils.zip_code_validate import validate_zip_code
 
@@ -39,6 +40,8 @@ def signup():
             new_cep = AddressModel(cep=cep)
             new_cep.city = city_query
             new_user.address = new_cep
+
+        insert_default_risk(new_user)
 
         session.commit()
     except ZipCodeNotFoundError as e:

--- a/app/controllers/user_risk_controller.py
+++ b/app/controllers/user_risk_controller.py
@@ -3,13 +3,13 @@ from http import HTTPStatus
 from flask import request
 from flask_jwt_extended import jwt_required
 
-from app.configs.database import db
 from app.exceptions.generic_exc import (
     InvalidKeysError,
     InvalidTypeError,
     MissingKeysError,
 )
 from app.exceptions.user_exc import UserNotFound
+from app.models.risk_model import RiskModel
 from app.services.generic_services import get_user_from_token
 from app.services.user_risk_profile_services import (
     select_risk_case,
@@ -20,7 +20,7 @@ from app.services.user_risk_profile_services import (
 @jwt_required()
 def create_user_risk_profile():
     try:
-        allowed_keys = ["live_nearby_river", "live_nearby_mountain"]
+        allowed_keys = list(RiskModel.VALIDATOR.keys())
         data = request.get_json()
         validate_keys_and_values(data, allowed_keys)
         user = get_user_from_token()

--- a/app/models/risk_model.py
+++ b/app/models/risk_model.py
@@ -19,6 +19,8 @@ class RiskModel(db.Model):
     title = Column(String, nullable=False, unique=True)
     text = Column(String, nullable=False)
 
+    VALIDATOR = {"live_nearby_river": bool, "live_nearby_mountain": bool}
+
     CASES = {
         "NOT_SPECIFIED": {"live_nearby_river": False, "live_nearby_mountain": False},
         "EARTH_SLIDING": {"live_nearby_river": False, "live_nearby_mountain": True},

--- a/app/services/user_risk_profile_services.py
+++ b/app/services/user_risk_profile_services.py
@@ -50,7 +50,7 @@ def select_risk_case(data: dict, user: UserModel):
         for key, value in data.items():
             if value == case_value[key]:
                 case_validator += 1
-            if case_validator == 2:
+            if case_validator == len(RiskModel.VALIDATOR):
                 selected_case = case_key
 
     message = RiskModel.VALUES[selected_case]
@@ -69,3 +69,10 @@ def select_risk_case(data: dict, user: UserModel):
     risk.users.append(user)
     session.add(risk)
     session.commit()
+
+
+def insert_default_risk(user: UserModel):
+
+    data = {key: False for key in RiskModel.VALIDATOR.keys()}
+
+    select_risk_case(data, user)

--- a/app/utils/phone_only_numbers_formatter.py
+++ b/app/utils/phone_only_numbers_formatter.py
@@ -1,0 +1,6 @@
+from re import sub
+
+
+def phone_with_only_numbers(phone: str):
+    formatted_phone = sub("[() -]", "", phone)
+    return formatted_phone

--- a/app/utils/zip_code_validate.py
+++ b/app/utils/zip_code_validate.py
@@ -2,7 +2,6 @@ import json
 
 from aiohttp import ClientSession
 from sqlalchemy.orm import Session
-from werkzeug import Client
 
 from app.configs.database import db
 from app.exceptions.city_exc import (


### PR DESCRIPTION
Created the sms send logic integration with the forecast route;
Added a validator to risk model;
Changed the risk profile logic a little to implement the validator;
Created a default risk service;
Created a phone numbers only formatter;
Deleted unnecessary imports.

I'll wait if the response is working, gotta try again in the morning, but i believe the logic is good.